### PR TITLE
fix(deps): allow ovos-bus-client 2.x (widen cap to <3.0.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 tornado~=6.0, >=6.0.3
-ovos_bus_client>=0.0.7,<2.0.0
+ovos_bus_client>=0.0.7,<3.0.0
 ovos-utils>=0.0.37,<1.0.0
 ovos-config>=0.0.12,<3.0.0


### PR DESCRIPTION
ovos-bus-client 2.x dropped only the bundled hivemind protocol + messagebus solver (#207) — no API break (#215). Widen `<2.0.0`→`<3.0.0` (1.x stays default). Stack-wide migration for HiveMind 2.x adoption.