### PR TITLE
fix: create asyncio event loop explicitly instead of deprecated implicit get_event_loop

### DIFF
--- a/ovos_messagebus/__main__.py
+++ b/ovos_messagebus/__main__.py
@@ -19,6 +19,8 @@ processes. It implements a websocket server so can also be used by external
 systems to integrate with the Mycroft system.
 """
 
+import asyncio
+
 from ovos_utils import create_daemon, wait_for_exit_signal
 from ovos_messagebus.load_config import load_message_bus_config
 from ovos_utils.log import LOG, init_service_logger
@@ -40,15 +42,24 @@ def on_stopping():
     LOG.info('Message bus is shutting down...')
 
 
+def _run_bus(config):
+    # Create and set an explicit asyncio event loop for this thread. tornado's
+    # IOLoop relies on there being a current asyncio loop, and asyncio no
+    # longer creates one implicitly via get_event_loop() on newer versions.
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    routes = [(config.route, MessageBusEventHandler)]
+    application = web.Application(routes)
+    application.listen(config.port, config.host)
+    ioloop.IOLoop.current().start()
+
+
 def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping):
     reset_sigint_handler()
     init_service_logger("bus")
     LOG.info('Starting message bus service...')
     config = load_message_bus_config()
-    routes = [(config.route, MessageBusEventHandler)]
-    application = web.Application(routes)
-    application.listen(config.port, config.host)
-    create_daemon(ioloop.IOLoop.instance().start)
+    create_daemon(_run_bus, args=(config,))
     ready_hook()
     wait_for_exit_signal()
     stopping_hook()


### PR DESCRIPTION
## Problem

Running `python -W always -m ovos_messagebus` on Python 3.12 logs:

```
tornado/ioloop.py:271: DeprecationWarning: There is no current event loop
```

`ovos_messagebus/__main__.py` called `application.listen(...)` on the main
thread, which implicitly created an asyncio event loop via the deprecated
`asyncio.get_event_loop()` alias, then handed off to a daemon thread running
`ioloop.IOLoop.instance().start()` — `IOLoop.instance()` is itself a
deprecated alias, and that thread never had an asyncio loop set on it at all.
This is purely incidental behavior that will break once `get_event_loop()`
stops creating implicit loops on future Python versions.

## Fix

Moved `application.listen()` and `ioloop.IOLoop.current().start()` into a
single function (`_run_bus`) that runs entirely on the daemon thread created
by `create_daemon`. That function starts by explicitly creating and setting
an asyncio event loop for the thread:

```python
loop = asyncio.new_event_loop()
asyncio.set_event_loop(loop)
```

`main()`'s structure, the `ready_hook`/`error_hook`/`stopping_hook` behavior,
and the public API are all unchanged.

## Smoke test performed

- Installed the branch in a clean venv (`uv pip install -e .` +
  `ovos-bus-client`).
- Ran the bus with `python -W error::DeprecationWarning -m ovos_messagebus`
  against a local config (`websocket`/`message_bus` on `127.0.0.1:8917`).
- Confirmed the process started cleanly with no warnings/exceptions and was
  listening on the configured port.
- Connected with `ovos_bus_client.MessageBusClient(host='127.0.0.1', port=8917)`
  and round-tripped a message through a bus-side handler — received the
  expected reply, no deprecation warnings raised anywhere in the client or
  server process.
- No test suite exists in this repo to run.

---
Authored with [Claude Code](https://claude.com/claude-code).