### PR TITLE
fix: refuse to start the webrockets backend when SSL is configured

### DIFF
--- a/ovos_messagebus/backends/webrockets_backend.py
+++ b/ovos_messagebus/backends/webrockets_backend.py
@@ -106,12 +106,15 @@ def _build_server(config) -> WebsocketServer:  # noqa: ANN001
     )
 
     if config.ssl:
-        LOG.warning(
-            "webrockets backend: SSL is configured in mycroft.conf but this "
-            "backend does not terminate TLS itself. Switch to the Tornado "
-            "backend (ovos_messagebus.__main__), which serves wss:// "
-            "directly, or put a TLS-terminating reverse proxy in front of "
-            "this backend."
+        raise RuntimeError(
+            "webrockets backend: SSL is configured (websocket.ssl is truthy) "
+            "but this backend cannot terminate TLS itself — webrockets "
+            "exposes no cert/key option. Refusing to start and silently "
+            "serve plaintext ws:// while clients dial wss://. Use one of: "
+            "(a) the Tornado backend (ovos_messagebus.__main__), which "
+            "serves wss:// directly via websocket.ssl_cert/ssl_key, or "
+            "(b) a TLS-terminating reverse proxy (nginx/traefik) in front "
+            "of this backend, with websocket.ssl unset for this process."
         )
 
     server = WebsocketServer(host=config.host, port=config.port)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 
 [project.optional-dependencies]
 ssl = ["cryptography>=3.4"]
-webrockets = ["webrockets>=0.1.5"]
+webrockets = ["webrockets>=0.2.1,<0.3.0"]
 benchmark = ["websockets>=12.0"]
 test = [
     "pytest>=7.0",

--- a/test/unittests/test_webrockets_backend.py
+++ b/test/unittests/test_webrockets_backend.py
@@ -158,19 +158,19 @@ class TestBuildServer(unittest.TestCase):
         self.assertIsNotNone(server._route._disconnect_handler)
 
     @patch("ovos_messagebus.backends.webrockets_backend.Configuration")
-    def test_ssl_warning_logged(self, cfg_patch):
+    def test_ssl_configured_raises(self, cfg_patch):
         cfg_patch.return_value.get.return_value = {}
-        with patch("ovos_messagebus.backends.webrockets_backend.LOG") as log:
+        with self.assertRaises(RuntimeError) as ctx:
             _build_server(_make_config(ssl=True))
-            log.warning.assert_called_once()
-            self.assertIn("SSL", log.warning.call_args[0][0])
+        self.assertIn("SSL", str(ctx.exception))
+        self.assertIn("Tornado", str(ctx.exception))
 
     @patch("ovos_messagebus.backends.webrockets_backend.Configuration")
-    def test_no_ssl_warning_when_ssl_off(self, cfg_patch):
+    def test_no_ssl_error_when_ssl_off(self, cfg_patch):
         cfg_patch.return_value.get.return_value = {}
-        with patch("ovos_messagebus.backends.webrockets_backend.LOG") as log:
-            _build_server(_make_config(ssl=None))
-            log.warning.assert_not_called()
+        # Must not raise when SSL is not configured.
+        server = _build_server(_make_config(ssl=None))
+        self.assertIsInstance(server, _FakeServer)
 
     @patch("ovos_messagebus.backends.webrockets_backend.Configuration")
     def test_route_path_strips_leading_slash(self, cfg_patch):
@@ -418,6 +418,37 @@ class TestMain(unittest.TestCase):
             main(error_hook=error)
 
         error.assert_called_once()
+
+    @patch("ovos_messagebus.backends.webrockets_backend.wait_for_exit_signal")
+    @patch("ovos_messagebus.backends.webrockets_backend._wait_for_server_ready")
+    @patch("ovos_messagebus.backends.webrockets_backend.threading")
+    @patch("ovos_messagebus.backends.webrockets_backend.load_message_bus_config")
+    @patch("ovos_messagebus.backends.webrockets_backend.init_service_logger")
+    @patch("ovos_messagebus.backends.webrockets_backend.reset_sigint_handler")
+    @patch("ovos_messagebus.backends.webrockets_backend.Configuration")
+    def test_ssl_configured_raises_and_never_starts_server(
+        self,
+        cfg_patch,
+        reset_sig,
+        init_log,
+        load_cfg,
+        threading_mock,
+        wait_ready_mock,
+        wait_exit,
+    ):
+        """SSL configured against the webrockets backend must fail loudly and
+        must NOT start the (plaintext-only) server."""
+        cfg_patch.return_value.get.return_value = {}
+        load_cfg.return_value = _make_config(ssl=True)
+
+        error = MagicMock()
+        with self.assertRaises(RuntimeError):
+            main(error_hook=error)
+
+        error.assert_called_once()
+        self.assertIn("SSL", error.call_args[0][0])
+        threading_mock.Thread.assert_not_called()
+        wait_ready_mock.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- webrockets cannot terminate TLS — its Python API (`WebsocketServer(host, port, broker=None)`) exposes no cert/key option, and upstream's documented TLS story is a terminating reverse proxy. Meanwhile `ovos-bus-client` builds `wss://` URLs straight off `websocket.ssl`, so with the webrockets backend + `ssl: true` every client dialed `wss://` at a plaintext server — silently, with only a log warning.
- `_build_server()` in `ovos_messagebus/backends/webrockets_backend.py` now raises `RuntimeError` when `config.ssl` is truthy, instead of warning and continuing. This routes through `main()`'s existing `try/except _build_server(): error_hook(str(exc)); raise` path, so the server is never started and the failure surfaces through the same lifecycle hooks as any other startup failure. The message names the two real options: the Tornado backend (serves `wss://` directly via `websocket.ssl_cert`/`ssl_key`), or a TLS-terminating reverse proxy in front with `websocket.ssl` unset for this process.
- Bounded the previously-unpinned `webrockets` extra: `webrockets>=0.2.1,<0.3.0` (was `>=0.1.5`, no upper bound). Verified against upstream's 0.2.1 API reference docs (`docs/src/content/docs/reference/{server,route,connection}.md` @ tag `v0.2.1`) that every symbol this backend calls — `WebsocketServer`, `create_route(path, default_group, authentication_classes)`, `@route.connect(when=...)`, `@route.receive`, `@route.disconnect`, `conn.broadcast(groups, message, exclude_self=False)` — is unchanged, so raising the floor to the current release is safe.

## Test plan
- [x] Updated `test/unittests/test_webrockets_backend.py`: replaced the old "warning logged" assertions with `test_ssl_configured_raises` / `test_no_ssl_error_when_ssl_off`, and added `test_ssl_configured_raises_and_never_starts_server` asserting `main()` raises, calls `error_hook`, and never starts the server thread.
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=<worktree> python -m pytest -q` → 58 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)