### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,28 @@
 # OVOS MessageBus
 
-messagebus service, the nervous system of OpenVoiceOS
+`ovos-messagebus` is the WebSocket message bus server for OpenVoiceOS. Every OVOS service connects to this bus and exchanges `Message` objects with it. The bus does not route or filter messages. It broadcasts each message to every connected client.
 
-## Alternative implementations
+## Install
 
-- [ovos-rust-messagebus](https://github.com/OscillateLabsLLC/ovos-rust-messagebus) - Alternative Rust messagebus server implementation
-- [ovos-messagebus-cpp](https://github.com/OpenVoiceOS/ovos-messagebus-cpp) - Alternative C++ messagebus server implementation using WebSocket++  (**archived**)
+```bash
+pip install ovos-messagebus
+```
 
-# Configuration
+## Usage
 
-under mycroft.conf
+Start the server from the command line:
+
+```bash
+ovos-messagebus
+```
+
+Or run it as a module:
+
+```bash
+python -m ovos_messagebus
+```
+
+The server reads its connection settings from `mycroft.conf` under the `websocket` key:
 
 ```javascript
 {
@@ -30,3 +43,25 @@ under mycroft.conf
   }
 }
 ```
+
+See [docs/configuration.md](docs/configuration.md) for the full list of options, [docs/server.md](docs/server.md) for the server internals, and [docs/events.md](docs/events.md) for the message types that flow through the bus.
+
+## Alternative implementations
+
+- [ovos-rust-messagebus](https://github.com/OscillateLabsLLC/ovos-rust-messagebus): alternative Rust messagebus server implementation.
+- [ovos-messagebus-cpp](https://github.com/OpenVoiceOS/ovos-messagebus-cpp): alternative C++ messagebus server implementation using WebSocket++ (archived).
+
+`ovos-messagebus` also ships an optional Rust-powered backend (`webrockets`) alongside its default Tornado backend. See [docs/backends.md](docs/backends.md) for setup and benchmark results.
+
+## Related projects
+
+- [ovos-bus-client](https://github.com/OpenVoiceOS/ovos-bus-client): the client library all services and skills use to connect to this bus.
+- [ovos-core](https://github.com/OpenVoiceOS/ovos-core): intent pipeline and skill orchestration. It connects to this bus as a client.
+- [ovos-audio](https://github.com/OpenVoiceOS/ovos-audio): TTS rendering and audio playback. It connects to this bus as a client.
+- [ovos-gui](https://github.com/OpenVoiceOS/ovos-gui): GUI namespace management. It bridges skills to GUI clients over this bus.
+- [ovos-dinkum-listener](https://github.com/OpenVoiceOS/ovos-dinkum-listener): wake word detection and STT transcription. It connects to this bus as a client.
+- [ovos-PHAL](https://github.com/OpenVoiceOS/ovos-PHAL): the hardware abstraction layer. It connects to this bus as a client.
+
+## License
+
+Apache-2.0. See [LICENSE](LICENSE).

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -1,8 +1,6 @@
-# Alternative Backends & Benchmarks
+# Alternative backends & benchmarks
 
-`ovos-messagebus` ships a pure-Python Tornado server by default.  Two
-additional backends are available for deployments that need higher throughput
-or lower latency.
+`ovos-messagebus` ships a pure-Python Tornado server by default. Two additional backends are available for deployments that need higher throughput or lower latency.
 
 ---
 
@@ -16,17 +14,17 @@ or lower latency.
 
 All three backends expose the same OVOS wire protocol:
 
-* WebSocket endpoint at `ws://<host>:<port>/<route>` (default `ws://0.0.0.0:8181/core`)
-* First message after connect is a JSON `{"msg_type": "connected", ...}` greeting
-* Every subsequent message is fan-out broadcast to **all** connected clients, including the sender
+* A WebSocket endpoint at `ws://<host>:<port>/<route>` (default `ws://0.0.0.0:8181/core`)
+* A JSON `{"msg_type": "connected", ...}` greeting as the first message after connect
+* Fan-out broadcast of every subsequent message to **all** connected clients, including the sender
 
 ---
 
 ## Tornado backend
 
-The reference implementation.  `MessageBusEventHandler`
+The reference implementation. `MessageBusEventHandler`
 (`ovos_messagebus/event_handler.py:30`) is a `tornado.websocket.WebSocketHandler`
-subclass.  Fan-out is an explicit Python loop:
+subclass. Fan-out is an explicit Python loop:
 
 ```python
 # ovos_messagebus/event_handler.py:77
@@ -34,10 +32,9 @@ for client in client_connections:
     client.write_message(message)
 ```
 
-Started via `ovos_messagebus.__main__.main` (`__main__.py:43`).
+`ovos_messagebus.__main__.main` (`__main__.py:43`) starts this backend.
 
-**Configuration** is read from `mycroft.conf["websocket"]` by
-`load_message_bus_config()` (`load_config.py:31`).
+`load_message_bus_config()` (`load_config.py:31`) reads its configuration from `mycroft.conf["websocket"]`.
 
 ---
 
@@ -58,21 +55,20 @@ pip install "ovos-messagebus[webrockets]"
 python -m ovos_messagebus.backends.webrockets_backend
 ```
 
-Reads the exact same `mycroft.conf["websocket"]` configuration as Tornado
+This backend reads the same `mycroft.conf["websocket"]` configuration as Tornado
 (`host`, `port`, `route`, `filter`, `filter_logs`).
 
 ### Architecture
 
-The backend (`ovos_messagebus/backends/webrockets_backend.py`) creates a
-`WebsocketServer` with the OVOS route registered via `create_route()`:
+`ovos_messagebus/backends/webrockets_backend.py` creates a
+`WebsocketServer` with the OVOS route registered through `create_route()`:
 
 ```python
 # webrockets_backend.py:75
 route = server.create_route(route_path, default_group=_GLOBAL_ROOM)
 ```
 
-`default_group=_GLOBAL_ROOM` means every connecting client is automatically
-placed in the broadcast room `__ovos_bus__`.  The receive handler then fans
+`default_group=_GLOBAL_ROOM` places every connecting client in the broadcast room `__ovos_bus__` automatically. The receive handler then fans
 out to everyone:
 
 ```python
@@ -80,10 +76,9 @@ out to everyone:
 conn.broadcast([_GLOBAL_ROOM], data, exclude_self=False)
 ```
 
-`exclude_self=False` (the webrockets default) ensures the sender also receives
-its own message — identical to the Tornado loop behaviour.
+`exclude_self=False` (the webrockets default) ensures the sender also receives its own message, matching the Tornado loop behavior.
 
-### Backwards-compatibility matrix
+### Backward-compatibility matrix
 
 | Feature | Tornado | webrockets |
 |---------|---------|------------|
@@ -93,24 +88,24 @@ its own message — identical to the Tornado loop behaviour.
 | Optional message filtering / logging | ✓ | ✓ |
 | `max_msg_size` enforcement | ✓ | ✗ (not exposed in Python API) |
 | SSL / TLS (server-terminated) | ✓ (serves `wss://` directly) | ✗ (use Tornado or a reverse proxy) |
-| `MessageBusEventHandler.on()` emitter | ✓ | ✗ (Tornado-internal; not used externally) |
+| `MessageBusEventHandler.on()` emitter | ✓ | ✗ (Tornado-internal, not used externally) |
 | Same `main()` hook signatures | ✓ | ✓ (drop-in) |
 
 ### Known limitations
 
-* **`max_msg_size`** — the `websocket.max_msg_size` config key is silently
-  ignored.  Use a reverse proxy (nginx, caddy) to enforce payload size limits
+* **`max_msg_size`**: this backend silently ignores the
+  `websocket.max_msg_size` config key. Use a reverse proxy (nginx, caddy) to enforce payload size limits
   if this matters in your deployment.
-* **SSL** — this backend does not terminate TLS at the Python layer. To serve
-  `wss://`, run the Tornado backend instead — it terminates TLS directly using
+* **SSL**: this backend does not terminate TLS at the Python layer. To serve
+  `wss://`, run the Tornado backend instead. It terminates TLS directly using
   the `websocket.ssl`, `websocket.ssl_cert`, and `websocket.ssl_key` config
   keys (generating a self-signed certificate under the XDG data directory
-  when the cert/key are unset). Alternatively, terminate TLS at a reverse
+  when the cert or key are unset). Alternatively, terminate TLS at a reverse
   proxy (nginx, caddy) in front of this backend and forward plain WebSocket
   traffic.
-* **`MessageBusEventHandler.on()` / `emitter`** — this Tornado-specific API
-  allows other in-process code to subscribe to bus messages via the handler
-  object.  It is not replicated by the webrockets backend because no external
+* **`MessageBusEventHandler.on()` / `emitter`**: this Tornado-specific API
+  lets other in-process code subscribe to bus messages through the handler
+  object. The webrockets backend does not replicate it, because no external
   OVOS code calls it.
 
 ---
@@ -118,7 +113,7 @@ its own message — identical to the Tornado loop behaviour.
 ## ovos-rust-messagebus
 
 A standalone Rust binary with zero Python overhead, developed by Oscillate
-Labs.  It speaks the same OVOS WebSocket protocol on port 8181.
+Labs. It speaks the same OVOS WebSocket protocol on port 8181.
 
 ### Build
 
@@ -138,7 +133,7 @@ docker run -p 8181:8181 ovos-rust-messagebus
 
 ### Configuration
 
-Via environment variables:
+Set these through environment variables:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -146,25 +141,25 @@ Via environment variables:
 | `OVOS_BUS_PORT` | `8181` | TCP port |
 | `OVOS_BUS_MAX_MSG_SIZE` | `25` MB | Maximum message payload size |
 
-Or via a YAML/JSON config file pointed to by `OVOS_BUS_CONFIG_FILE`.
+Or point `OVOS_BUS_CONFIG_FILE` at a YAML or JSON config file.
 
 ---
 
 ## Benchmark results
 
 Measured on **localhost** (loopback, no network overhead) using
-`benchmark/run_benchmark.py`.  A single sender publishes N messages; M
-subscriber clients each receive every broadcast.  Throughput is total fan-out
-deliveries per second (`N × M / elapsed`).  Latency is measured by embedding
+`benchmark/run_benchmark.py`. A single sender publishes N messages. M
+subscriber clients each receive every broadcast. Throughput is the total fan-out
+deliveries per second (`N × M / elapsed`). Latency is measured by embedding
 a timestamp in each message and recording it at the receiver.
 
 Machine: Linux 6.18.16-1-lts, Intel i7, CPython 3.11.14
 Rust binary: `ovos-rust-messagebus` v1.1.2, compiled from source with `cargo build --release`
 
-> **Methodology note**: Errors in the Rust results at 100 clients are WebSocket
-> connection rejections at connect time (not delivery failures).  They affect the
+> **Methodology note**: The errors in the Rust results at 100 clients are WebSocket
+> connection rejections at connect time, not delivery failures. They affect the
 > connection count but not the per-message latency of connections that succeeded.
-> Results with ≥ 10 errors should be read with caution.
+> Read results with 10 or more errors with caution.
 
 ### 5 clients × 200 messages
 
@@ -196,13 +191,13 @@ Rust binary: `ovos-rust-messagebus` v1.1.2, compiled from source with `cargo bui
 |---------|-----------|-------------|----------------|-----|-----|-------------|---------|--------|
 | Tornado | 74,154 msg/s | 11.1 ms | 360.4 ms | 640.5 ms | 666.0 ms | 670.0 ms | 0 | 0 |
 | **webrockets** | **76,799 msg/s** | 120.3 ms | **369.9 ms** | **618.2 ms** | **639.6 ms** | **643.9 ms** | 0 | 0 |
-| Rust ⚠ | 128,588 msg/s† | 21.2 ms | 31,562 ms | 31,765 ms | 31,785 ms | 31,792 ms | 0 | 28 |
+| Rust (!) | 128,588 msg/s† | 21.2 ms | 31,562 ms | 31,765 ms | 31,785 ms | 31,792 ms | 0 | 28 |
 
-† Throughput is inflated because 28 subscriber connections were rejected at
-connect time, so denominator is over-counted.  Median latency of 31 s for
+† Throughput looks inflated because 28 subscriber connections were rejected at
+connect time, so the denominator is over-counted. The 31 s median latency of
 the 72 successful connections shows server saturation.
 
-### Summary — Throughput vs Tornado baseline
+### Summary: throughput vs. Tornado baseline
 
 ```
   Scenario          Tornado       webrockets    Rust            Winner
@@ -210,10 +205,10 @@ the 72 successful connections shows server saturation.
   5c × 200m       48,820/s      54,103/s      57,770/s        Rust  (+18%)
   20c × 1,000m    65,937/s      71,841/s      78,849/s        Rust  (+20%)
   50c × 2,000m    63,858/s      78,891/s      76,585/s        webrockets (+24%)
-  100c × 500m     74,154/s      76,799/s      ⚠ 28 errors     webrockets (+4%)
+  100c × 500m     74,154/s      76,799/s      28 errors       webrockets (+4%)
 ```
 
-### Summary — p99 latency (lower is better)
+### Summary: p99 latency (lower is better)
 
 ```
   Scenario          Tornado       webrockets    Rust
@@ -226,32 +221,33 @@ the 72 successful connections shows server saturation.
 
 ### Observations
 
-1. **Rust wins at low-to-medium concurrency** (5–20 clients): +18–20%
-   throughput vs Tornado and +7–10% vs webrockets, with the lowest p99
+1. **Rust wins at low-to-medium concurrency** (5 to 20 clients): +18-20%
+   throughput vs. Tornado and +7-10% vs. webrockets, with the lowest p99
    latency at every measured load in this range.
 
-2. **webrockets wins at high concurrency** (50+ clients): +24% throughput
-   vs Tornado at 50 clients, and best p99 tail latency.  The Rust binary
-   begins to show connection-level saturation above ~50 simultaneous clients
+2. **webrockets wins at high concurrency** (50 or more clients): +24% throughput
+   vs. Tornado at 50 clients, and the best p99 tail latency. The Rust binary
+   shows connection-level saturation above about 50 simultaneous clients
    under the default configuration.
 
 3. **Tornado's latency minimum is lowest** at low concurrency (2.6 ms at
-   5 clients) — the pure-Python asyncio path has no FFI overhead.
+   5 clients). The pure-Python asyncio path has no FFI overhead.
 
-4. **Rust connection saturation at 100 clients**: 28 out of 100 subscriber
+4. **Rust connection saturation at 100 clients**: 28 of 100 subscriber
    connections were rejected, causing 31-second median latency for survivors.
-   The Rust server likely needs tuning (`--max-connections` or OS socket
-   backlog) for > 50 concurrent clients.
+   The Rust server likely needs tuning (`--max-connections` or the OS socket
+   backlog) for more than 50 concurrent clients.
 
-5. **Zero message drops for Tornado and webrockets** at all tested loads.
+5. **Neither Tornado nor webrockets drop any messages** at any tested load.
 
 6. **The Rust binary is the best choice** for typical OVOS deployments
-   (1–20 concurrent components on a single host) where connections are
-   long-lived.  For HiveMind satellite hubs with 50+ concurrent nodes,
+   (1 to 20 concurrent components on a single host) where connections stay
+   long-lived. For HiveMind satellite hubs with 50 or more concurrent nodes,
    webrockets is currently more stable.
 
-7. **Tornado remains a solid default**: pure-Python, no native extensions,
-   well-understood asyncio scheduling, and lowest setup friction.
+7. **Tornado remains a solid default**: it is pure Python, uses no native
+   extensions, has well-understood asyncio scheduling, and needs the least
+   setup.
 
 ---
 
@@ -282,12 +278,15 @@ python benchmark/run_benchmark.py --compare \
 
 ### Benchmark methodology
 
-* **Warmup phase**: `--warmup` messages (default 10) sent and received before
-  measurement begins, ensuring JIT warm-up and connection pool readiness.
+* **Warmup phase**: the benchmark sends and receives `--warmup` messages
+  (default 10) before measurement begins, to warm up the JIT and connection pool.
 * **Timestamp embedding**: each message carries a `_bench_ts` float (Unix
-  seconds from `time.perf_counter()`); latency = receive time − send time.
-* **Fan-out accounting**: throughput counts every (sender → subscriber) pair
+  seconds from `time.perf_counter()`). Latency is the receive time minus the send time.
+* **Fan-out accounting**: throughput counts every sender-to-subscriber pair
   delivery, not just messages sent.
-* **Backpressure**: the sender sends all messages without waiting; the
-  receivers drain concurrently.  Messages not received within `--timeout`
-  seconds are counted as dropped.
+* **Backpressure**: the sender sends all messages without waiting. The
+  receivers drain concurrently. Messages not received within `--timeout`
+  seconds count as dropped.
+
+---
+[← Events](events.md) · [Home](index.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,11 +1,10 @@
-
 # Configuration
 
-`ovos-messagebus` reads all connection and behaviour settings from `mycroft.conf` under the `websocket` key. The config file is located at `~/.config/mycroft/mycroft.conf` (user) or `/etc/mycroft/mycroft.conf` (system).
+`ovos-messagebus` reads all connection and behavior settings from `mycroft.conf` under the `websocket` key. The config file lives at `~/.config/mycroft/mycroft.conf` (user) or `/etc/mycroft/mycroft.conf` (system).
 
 ---
 
-## Full Reference
+## Full reference
 
 ```json
 {
@@ -23,7 +22,7 @@
 }
 ```
 
-Defaults are sourced from `ovos_config/mycroft.conf` in the `ovos-config` package.
+The defaults come from `ovos_config/mycroft.conf` in the `ovos-config` package.
 
 ---
 
@@ -37,10 +36,10 @@ Defaults are sourced from `ovos_config/mycroft.conf` in the `ovos-config` packag
 
 The network interface the Tornado server binds to.
 
-- `"127.0.0.1"` — loopback only (default; restricts to local process connections — all OVOS services run on the same host)
-- `"0.0.0.0"` — accept connections from any interface (required when HiveMind satellites or remote services connect over the network)
+- `"127.0.0.1"`: loopback only. This is the default. It restricts connections to the local host, since all OVOS services run on the same host.
+- `"0.0.0.0"`: accepts connections from any interface. Use this when HiveMind satellites or remote services connect over the network.
 
-All OVOS services that connect via `ovos-bus-client` read `host` from the same `mycroft.conf` to know where to connect.
+Every OVOS service that connects through `ovos-bus-client` reads `host` from the same `mycroft.conf` to find the bus.
 
 ---
 
@@ -50,7 +49,7 @@ All OVOS services that connect via `ovos-bus-client` read `host` from the same `
 **Default:** `8181`
 **Source:** `load_config.py` → `MessageBusConfig`
 
-TCP port the WebSocket server listens on. The standard OVOS port is `8181`. The `ovos-gui` service uses a separate port (`18181` by default) for its own WebSocket.
+The TCP port the WebSocket server listens on. The standard OVOS port is `8181`. `ovos-gui` uses a separate port (`18181` by default) for its own WebSocket.
 
 ---
 
@@ -60,9 +59,9 @@ TCP port the WebSocket server listens on. The standard OVOS port is `8181`. The 
 **Default:** `"/core"`
 **Source:** `load_config.py` → `MessageBusConfig`
 
-The URL path that `MessageBusEventHandler` is mounted on. The full WebSocket URL becomes `ws://<host>:<port><route>`, e.g. `ws://localhost:8181/core`.
+The URL path `MessageBusEventHandler` mounts on. The full WebSocket URL becomes `ws://<host>:<port><route>`, for example `ws://localhost:8181/core`.
 
-All `ovos-bus-client` connections use the same `route` value from config.
+Every `ovos-bus-client` connection uses the same `route` value from config.
 
 ---
 
@@ -70,7 +69,7 @@ All `ovos-bus-client` connections use the same `route` value from config.
 
 **Type:** boolean
 **Default:** `false`
-**Source:** `load_config.py` → `MessageBusConfig` — read from `mycroft.conf["websocket"]["ssl"]` (`load_config.py:46`)
+**Source:** `load_config.py` → `MessageBusConfig`, read from `mycroft.conf["websocket"]["ssl"]` (`load_config.py:46`)
 
 When `true`, the Tornado server starts with SSL/TLS enabled and serves `wss://` directly. When `false`, the server uses plain WebSocket (`ws://`).
 
@@ -80,11 +79,11 @@ When `true`, the Tornado server starts with SSL/TLS enabled and serves `wss://` 
 
 **Type:** string (file path)
 **Default:** unset
-**Source:** `__main__.py::_get_ssl_options()` — read from `mycroft.conf["websocket"]["ssl_cert"]` / `["ssl_key"]`
+**Source:** `__main__.py::_get_ssl_options()`, read from `mycroft.conf["websocket"]["ssl_cert"]` / `["ssl_key"]`
 
-Paths to a PEM certificate and private key used for the Tornado server's TLS listener when `ssl` is `true`. If left unset, a self-signed certificate/key pair is generated automatically (via `ovos_messagebus/ssl_utils.py`, RSA-2048/SHA-256) and cached under the XDG data directory; this requires the `cryptography` package (the `ssl` extra: `pip install "ovos-messagebus[ssl]"`).
+Paths to a PEM certificate and private key the Tornado server uses for its TLS listener when `ssl` is `true`. If you leave them unset, the server generates a self-signed certificate and key pair automatically (through `ovos_messagebus/ssl_utils.py`, RSA-2048/SHA-256) and caches the pair under the XDG data directory. This requires the `cryptography` package (the `ssl` extra: `pip install "ovos-messagebus[ssl]"`).
 
-The webrockets backend does not terminate TLS itself — it has no cert/key parameters to set. To serve `wss://` use the Tornado backend, or put a TLS-terminating reverse proxy in front of the webrockets backend instead.
+The webrockets backend does not terminate TLS itself. It has no cert or key parameters to set. To serve `wss://`, use the Tornado backend, or put a TLS-terminating reverse proxy in front of the webrockets backend instead.
 
 ---
 
@@ -94,13 +93,13 @@ The webrockets backend does not terminate TLS itself — it has no cert/key para
 **Default:** `10`
 **Source:** `event_handler.py` → `MessageBusEventHandler.max_message_size`
 
-Maximum WebSocket frame size in megabytes. Computed as:
+The maximum WebSocket frame size in megabytes. The server computes it as:
 
 ```python
 config.get("websocket", {}).get("max_msg_size", 25) * 1024 * 1024
 ```
 
-Default per `ovos_config/mycroft.conf`: `25` MB. Messages larger than this limit cause Tornado to close the connection. Increase this value if you are passing large payloads (e.g. base64-encoded images via `gui.page.upload`).
+Default per `ovos_config/mycroft.conf`: `25` MB. Messages larger than this limit cause Tornado to close the connection. Increase this value if you pass large payloads (for example base64-encoded images through `gui.page.upload`).
 
 ---
 
@@ -110,9 +109,9 @@ Default per `ovos_config/mycroft.conf`: `25` MB. Messages larger than this limit
 **Default:** `false`
 **Source:** `event_handler.py` → `MessageBusEventHandler.filter`
 
-When `true`, enables debug logging of all message types before broadcast. Each message logs its type, source list, destination list, and the current session state.
+When `true`, the server enables debug logging of all message types before it broadcasts them. Each log entry shows the message type, source list, destination list, and the current session state.
 
-Messages listed in `filter_logs` are excluded from this log to reduce noise.
+Message types listed in `filter_logs` are excluded from this log to reduce noise.
 
 Enabling `filter` does **not** affect message delivery.
 
@@ -124,15 +123,15 @@ Enabling `filter` does **not** affect message delivery.
 **Default:** `["gui.status.request", "gui.page.upload"]`
 **Source:** `event_handler.py` → `MessageBusEventHandler.filter_logs`
 
-When `filter` is `true`, message types in this list are not logged. The default excludes high-frequency GUI polling messages that would flood the log.
+When `filter` is `true`, the server does not log message types in this list. The default excludes high-frequency GUI polling messages that would flood the log.
 
-Only has an effect when `filter: true`.
+This setting only has an effect when `filter: true`.
 
 ---
 
-## `load_message_bus_config()` Override
+## `load_message_bus_config()` override
 
-The `load_message_bus_config()` function accepts keyword arguments that override values read from `mycroft.conf`. This is used internally by the `main()` entry point to apply command-line arguments:
+`load_message_bus_config()` accepts keyword arguments that override values read from `mycroft.conf`. The `main()` entry point uses this internally to apply command-line arguments:
 
 ```python
 from ovos_messagebus.load_config import load_message_bus_config
@@ -143,8 +142,11 @@ config = load_message_bus_config(port=8182)
 
 ---
 
-## Further Reading
+## Further reading
 
-- [Server](server.md) — `MessageBusEventHandler`, `load_message_bus_config()`, `main()`
-- [Events](events.md) — Message types that flow through the bus
-- [ovos-config](https://github.com/OpenVoiceOS/ovos-config) — `mycroft.conf` location and loading
+- [Server](server.md): `MessageBusEventHandler`, `load_message_bus_config()`, `main()`
+- [Events](events.md): message types that flow through the bus
+- [ovos-config](https://github.com/OpenVoiceOS/ovos-config): `mycroft.conf` location and loading
+
+---
+[← Server](server.md) · [Home](index.md) · [Events →](events.md)

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,15 +1,14 @@
+# Bus events
 
-# Bus Events
+`ovos-messagebus` is a **pure fan-out broker**. It does not publish, filter, or transform any messages. It forwards every message from one client to every connected client, verbatim. This page documents the message types that flow through the bus in a standard OVOS deployment.
 
-`ovos-messagebus` is a **pure fan-out broker**. It does not publish, filter, or transform any messages — every message received from one client is forwarded verbatim to every connected client. This page documents the message types that flow through the bus in a standard OVOS deployment.
-
-The bus itself recognises only one special message type: `connected` (emitted to a new client immediately after it opens a WebSocket connection). All other message types are application-level concerns of the services that connect to the bus.
+The bus itself recognizes only one special message type: `connected` (sent to a new client immediately after it opens a WebSocket connection). Every other message type is an application-level concern of the services that connect to the bus.
 
 ---
 
 ## `connected` (bus → new client only)
 
-Sent by `MessageBusEventHandler.open()` to the newly connected client when the WebSocket handshake completes. Not broadcast to other clients.
+`MessageBusEventHandler.open()` sends this message to the newly connected client when the WebSocket handshake completes. The bus does not broadcast it to other clients.
 
 ```json
 {
@@ -21,11 +20,11 @@ Sent by `MessageBusEventHandler.open()` to the newly connected client when the W
 
 ---
 
-## Message Categories (application-level)
+## Message categories (application-level)
 
-The following categories represent messages that flow through the bus. They are published and consumed by the OVOS services listed below — not by the bus itself.
+The following categories are messages that flow through the bus. The OVOS services listed below publish and consume them. The bus itself does not.
 
-### Core / Intent Pipeline
+### Core / intent pipeline
 
 | Message type | Publisher | Consumers |
 |---|---|---|
@@ -42,7 +41,7 @@ The following categories represent messages that flow through the bus. They are 
 | `mycroft.skill.handler.start` | `ovos-core` | GUI clients |
 | `mycroft.skill.handler.complete` | `ovos-core` | GUI clients |
 
-### GUI Namespace Protocol
+### GUI namespace protocol
 
 | Message type | Publisher | Consumers |
 |---|---|---|
@@ -59,7 +58,7 @@ The following categories represent messages that flow through the bus. They are 
 | `mycroft.device.show.idle` | `ovos-core` | `ovos-shell`, GUI clients |
 | `ovos.homescreen.displayed` | `ovos-skill-homescreen` | `ovos-gui` |
 
-### Homescreen Data (raspOVOS / legacy Qt plugin)
+### Homescreen data (raspOVOS / legacy Qt plugin)
 
 | Message type | Publisher | Consumers |
 |---|---|---|
@@ -83,7 +82,7 @@ The following categories represent messages that flow through the bus. They are 
 | `ovos.common_play.track_info.response` | `ovos-audio` | GUI clients |
 | `gui.player.media.service.sync.status` | `ovos-audio` | `HomescreenManager` |
 
-### PHAL / System
+### PHAL / system
 
 | Message type | Publisher | Consumers |
 |---|---|---|
@@ -96,23 +95,26 @@ The following categories represent messages that flow through the bus. They are 
 
 ---
 
-## Filter / Debug Mode
+## Filter / debug mode
 
-When `mycroft.conf["websocket"]["filter"] = true`, the bus logs each message type and session info before broadcasting:
+When `mycroft.conf["websocket"]["filter"] = true`, the bus logs each message type and session info before it broadcasts the message:
 
 ```
 DEBUG: <msg_type> source: [...] destination: [...]
        SESSION: {...}
 ```
 
-Messages listed in `filter_logs` are excluded from the log (default: `["gui.status.request", "gui.page.upload"]`).
+The bus excludes message types listed in `filter_logs` from this log (default: `["gui.status.request", "gui.page.upload"]`).
 
-Filter mode does **not** affect message delivery — all messages are still broadcast to all clients, including malformed or non-OVOS frames that fail deserialization. Deserialization failures are logged at DEBUG level and the raw payload is forwarded unchanged (`MessageBusEventHandler.on_message` — `event_handler.py:61`).
+Filter mode does **not** affect message delivery. The bus still broadcasts every message to every client, including malformed or non-OVOS frames that fail deserialization. It logs deserialization failures at DEBUG level and forwards the raw payload unchanged (`MessageBusEventHandler.on_message`, `event_handler.py:61`).
 
 ---
 
-## Further Reading
+## Further reading
 
-- [Server](server.md) — `MessageBusEventHandler` implementation
-- [Configuration](configuration.md) — `filter`, `filter_logs`, and all connection settings
-- [ovos-bus-client](https://github.com/OpenVoiceOS/ovos-bus-client) — client library used by all services
+- [Server](server.md): `MessageBusEventHandler` implementation
+- [Configuration](configuration.md): `filter`, `filter_logs`, and all connection settings
+- [ovos-bus-client](https://github.com/OpenVoiceOS/ovos-bus-client): client library used by all services
+
+---
+[← Configuration](configuration.md) · [Home](index.md) · [Backends & Benchmarks →](backends.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,3 @@
-
 # ovos-messagebus
 
 `ovos-messagebus` is the WebSocket message bus server for OpenVoiceOS. All OVOS services communicate by publishing and subscribing to typed `Message` objects through this central broker.
@@ -29,37 +28,39 @@
     (clients via ovos-bus-client)
 ```
 
-All messages are JSON-serialized `Message(type, data, context)` objects. The bus performs no filtering or routing — every message is broadcast to every connected client.
+Every message is a JSON-serialized `Message(type, data, context)` object. The bus does not filter or route messages. It broadcasts each message to every connected client.
 
 ---
 
-## Running the Server
+## Running the server
 
-```bash
-python -m ovos_messagebus
-```
-
-Or via the installed entry point:
+Start the server from the installed entry point:
 
 ```bash
 ovos-messagebus
 ```
 
-The server reads connection parameters from `mycroft.conf` (`websocket` section) and starts listening. It blocks until a shutdown signal is received.
+Or run it as a module:
+
+```bash
+python -m ovos_messagebus
+```
+
+The server reads its connection settings from `mycroft.conf` (the `websocket` section), then starts listening. It blocks until it receives a shutdown signal.
 
 ---
 
 ## Configuration
 
-Configuration is read from `mycroft.conf` under the `websocket` key:
+The server reads its configuration from `mycroft.conf` under the `websocket` key:
 
 | Key | Default | Description |
 |---|---|---|
 | `host` | `0.0.0.0` | Bind address |
 | `port` | `8181` | TCP port |
 | `route` | `/core` | WebSocket URL path |
-| `ssl` | `False` | Enable SSL/TLS (Tornado backend serves `wss://` directly) |
-| `ssl_cert` / `ssl_key` | unset | PEM cert/key paths; self-signed pair auto-generated when unset (`ssl` extra) |
+| `ssl` | `False` | Enable SSL/TLS (the Tornado backend serves `wss://` directly) |
+| `ssl_cert` / `ssl_key` | unset | PEM cert/key paths. The server generates a self-signed pair when unset (`ssl` extra) |
 | `max_msg_size` | `10` | Maximum message size in MB |
 
 Example `mycroft.conf` section:
@@ -80,12 +81,12 @@ Example `mycroft.conf` section:
 
 ---
 
-## Package Layout
+## Package layout
 
 ```
 ovos_messagebus/
 ├── __init__.py
-├── __main__.py              # Entry point: main() — Tornado backend
+├── __main__.py              # Entry point: main(), the Tornado backend
 ├── event_handler.py         # MessageBusEventHandler (Tornado WebSocketHandler)
 ├── load_config.py           # load_message_bus_config() → MessageBusConfig
 └── backends/
@@ -98,27 +99,27 @@ benchmark/
 
 ---
 
-## Further Reading
+## Further reading
 
-- [Server](server.md) — `MessageBusEventHandler`, `load_message_bus_config`, `main()`
-- [Configuration](configuration.md) — Full `mycroft.conf["websocket"]` reference: host, port, route, ssl, ssl_cert, ssl_key, max_msg_size, filter, filter_logs
-- [Events](events.md) — Message types that flow through the bus and which services publish/consume them
-- [Backends & Benchmarks](backends.md) — webrockets and Rust backends, measured throughput/latency results, how to run comparisons
+- [Server](server.md): `MessageBusEventHandler`, `load_message_bus_config`, `main()`
+- [Configuration](configuration.md): full `mycroft.conf["websocket"]` reference: host, port, route, ssl, ssl_cert, ssl_key, max_msg_size, filter, filter_logs
+- [Events](events.md): message types that flow through the bus and which services publish and consume them
+- [Backends & Benchmarks](backends.md): the webrockets and Rust backends, measured throughput and latency results, and how to run comparisons
 
 ---
 
-## Services That Connect to the Bus
+## Services that connect to the bus
 
-Every OVOS service connects to the bus as a client via [ovos-bus-client](https://github.com/OpenVoiceOS/ovos-bus-client). The bus itself does not know about these services — it simply broadcasts every message to every connected client.
+Every OVOS service connects to the bus as a client through [ovos-bus-client](https://github.com/OpenVoiceOS/ovos-bus-client). The bus itself does not know about these services. It just broadcasts every message to every connected client.
 
 | Service | Role |
 |---|---|
 | [ovos-core](https://github.com/OpenVoiceOS/ovos-core) | Intent pipeline, skill orchestration |
 | [ovos-audio](https://github.com/OpenVoiceOS/ovos-audio) | TTS rendering and audio playback |
-| [ovos-gui](https://github.com/OpenVoiceOS/ovos-gui) | GUI namespace management; bridges skills to GUI clients |
+| [ovos-gui](https://github.com/OpenVoiceOS/ovos-gui) | GUI namespace management. It bridges skills to GUI clients |
 | [ovos-dinkum-listener](https://github.com/OpenVoiceOS/ovos-dinkum-listener) | Wake word detection and STT transcription |
 | [ovos-PHAL](https://github.com/OpenVoiceOS/ovos-PHAL) | Hardware abstraction layer (connectivity, audio hardware, etc.) |
 | [ovos-bus-client](https://github.com/OpenVoiceOS/ovos-bus-client) | Client library used by all services and skills |
-| [ovos-workshop](https://github.com/OpenVoiceOS/ovos-workshop) | Skill base classes (indirectly via ovos-bus-client) |
+| [ovos-workshop](https://github.com/OpenVoiceOS/ovos-workshop) | Skill base classes (indirectly through ovos-bus-client) |
 
-GUI clients (e.g. `ovos-shell`, `pyhtmx-gui-client`) connect to `ovos-gui`'s own WebSocket (`ws://localhost:18181/gui`), not directly to the messagebus.
+GUI clients (for example `ovos-shell`, `pyhtmx-gui-client`) connect to `ovos-gui`'s own WebSocket (`ws://localhost:18181/gui`), not directly to the messagebus.

--- a/docs/server.md
+++ b/docs/server.md
@@ -1,15 +1,14 @@
-
 # Server
 
 ## `MessageBusEventHandler`
 
 **Module:** `ovos_messagebus.event_handler.MessageBusEventHandler`
 
-Tornado `WebSocketHandler` subclass that implements the OVOS message bus. All connected clients share a single module-level connection list (`client_connections` in `event_handler.py:27`); every received message is broadcast to every client.
+`MessageBusEventHandler` is a Tornado `WebSocketHandler` subclass that implements the OVOS message bus. All connected clients share a single module-level connection list (`client_connections` in `event_handler.py:27`). The handler broadcasts every received message to every client.
 
 ---
 
-### Module Attributes
+### Module attributes
 
 | Attribute | Type | Description |
 |---|---|---|
@@ -17,17 +16,17 @@ Tornado `WebSocketHandler` subclass that implements the OVOS message bus. All co
 
 ---
 
-### Key Methods
+### Key methods
 
 #### `open()`
 
-Called when a new WebSocket connection is established. Writes a `connected` message (with `context.session.session_id = "default"`) to the new client only, then appends `self` to the module-level `client_connections` list.
+Tornado calls `open()` when a new WebSocket connection opens. The method writes a `connected` message (with `context.session.session_id = "default"`) to the new client only, then appends `self` to the module-level `client_connections` list.
 
 #### `on_message(message)`
 
-Called for each incoming WebSocket frame. Broadcasts the raw message string to **all** connections in `client_connections` (including the sender) by calling `write_message()` on each.
+Tornado calls `on_message()` for each incoming WebSocket frame. The handler broadcasts the raw message string to **all** connections in `client_connections` (including the sender) by calling `write_message()` on each.
 
-When `self.filter` is `True` (read from `mycroft.conf["websocket"]["filter"]`), the message is first deserialized and its type, source, destination, and session are logged — unless the type is in `filter_logs`. If deserialization fails the failure is logged at DEBUG level and the raw frame is still broadcast unchanged. This is used for debug monitoring and does **not** affect delivery.
+When `self.filter` is `True` (read from `mycroft.conf["websocket"]["filter"]`), the handler deserializes the message first and logs its type, source, destination, and session, unless the type is in `filter_logs`. If deserialization fails, the handler logs the failure at DEBUG level and still broadcasts the raw frame unchanged. This filter mode supports debug monitoring only. It does not affect delivery.
 
 #### `on_close()`
 
@@ -35,7 +34,7 @@ Removes the handler from `client_connections` when the connection drops.
 
 #### `check_origin(origin) → bool`
 
-Always returns `True`. OVOS does not enforce CORS/origin checks — any WebSocket client can connect.
+Always returns `True`. OVOS does not enforce CORS or origin checks. Any WebSocket client can connect.
 
 #### `max_message_size` (property)
 
@@ -49,9 +48,9 @@ Default: 10 MB.
 
 ---
 
-### Broadcast Behaviour
+### Broadcast behavior
 
-The bus is a pure fan-out: no routing, no filtering, no topic subscriptions at the server level. Every message every client sends is forwarded to every client. Subscription filtering is handled entirely in the client library (`ovos-bus-client`).
+The bus is a pure fan-out. It does no routing, no filtering, and no topic subscriptions at the server level. The bus forwards every message from every client to every client. Subscription filtering happens entirely in the client library (`ovos-bus-client`).
 
 ---
 
@@ -66,7 +65,7 @@ config = load_message_bus_config()
 # config.host, config.port, config.route, config.ssl
 ```
 
-Reads `mycroft.conf["websocket"]` and returns a `MessageBusConfig` namedtuple:
+`load_message_bus_config()` reads `mycroft.conf["websocket"]` and returns a `MessageBusConfig` namedtuple:
 
 | Field | Source key | Default |
 |---|---|---|
@@ -75,7 +74,7 @@ Reads `mycroft.conf["websocket"]` and returns a `MessageBusConfig` namedtuple:
 | `route` | `route` | `/core` |
 | `ssl` | `ssl` | `False` |
 
-Keyword arguments passed to `load_message_bus_config()` override values from config:
+Keyword arguments passed to `load_message_bus_config()` override values from the config file:
 
 ```python
 config = load_message_bus_config(port=8182)
@@ -97,14 +96,17 @@ main()
 
 Execution flow:
 
-1. Call `load_message_bus_config()` to get host/port/route/ssl settings
-2. Build a Tornado `web.Application` mapping `config.route` → `MessageBusEventHandler`
-3. If `config.ssl` is truthy, resolve `ssl_options` from `websocket.ssl_cert`/`websocket.ssl_key`
+1. Call `load_message_bus_config()` to get the host, port, route, and ssl settings.
+2. Build a Tornado `web.Application` that maps `config.route` to `MessageBusEventHandler`.
+3. If `config.ssl` is truthy, resolve `ssl_options` from `websocket.ssl_cert` and `websocket.ssl_key`
    (generating and caching a self-signed certificate under the XDG data directory when unset),
-   then bind the application to `config.port` / `config.host` with those `ssl_options`, serving
+   then bind the application to `config.port` and `config.host` with those `ssl_options`, serving
    `wss://`. Otherwise bind it plainly, serving `ws://`.
-4. Start the Tornado `IOLoop` in a **daemon thread**
-5. Block the main thread on `wait_for_exit_signal()` (from `ovos-utils`)
-6. On signal (SIGTERM/SIGINT), the daemon thread exits with the process
+4. Start the Tornado `IOLoop` in a **daemon thread**.
+5. Block the main thread on `wait_for_exit_signal()` (from `ovos-utils`).
+6. On signal (SIGTERM or SIGINT), the daemon thread exits with the process.
 
-The daemon thread design means the IOLoop is automatically terminated when the main thread receives a shutdown signal — no explicit cleanup is required.
+Because the IOLoop runs in a daemon thread, it terminates automatically when the main thread receives a shutdown signal. No explicit cleanup step is needed.
+
+---
+[Home](index.md) · [Configuration →](configuration.md)


### PR DESCRIPTION
Rewrites README.md and docs/*.md for clarity, keeping every fact, code block, and license section. Adds an install/usage section to the README, a related-projects list, and standard footer navigation (relative links) across the docs/ pages.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded project documentation with installation, usage, configuration, licensing, and related-project information.
  * Clarified backend options, Rust backend compatibility, limitations, and benchmark results.
  * Updated configuration guidance, including TLS, certificates, defaults, filtering, and overrides.
  * Improved event bus, server, startup, shutdown, and client connection documentation.
  * Refined terminology, formatting, navigation, and command examples throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->