### PR TITLE
docs: cross-link the technical manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,29 +22,11 @@ Or run it as a module:
 python -m ovos_messagebus
 ```
 
-The server reads its connection settings from `mycroft.conf` under the `websocket` key:
-
-```javascript
-{
-  // The mycroft-core messagebus websocket
-  "websocket": {
-    "host": "0.0.0.0",
-    "port": 8181,
-    "route": "/core",
-    "ssl": false,
-    // in mycroft-core all skills share a bus, this allows malicious skills
-    // to manipulate it and affect other skills, this option ensures each skill
-    // gets its own websocket connection
-    "shared_connection": true,
-    // filter out messages of certain types from the bus logs
-    "filter": false,
-    // which messages to filter if filter is enabled
-    "filter_logs": ["gui.status.request", "gui.page.upload"]
-  }
-}
-```
-
-See [docs/configuration.md](docs/configuration.md) for the full list of options, [docs/server.md](docs/server.md) for the server internals, and [docs/events.md](docs/events.md) for the message types that flow through the bus.
+The server reads its connection settings from `mycroft.conf` under the `websocket` key. The shipped
+default `host` is `127.0.0.1`; keep it that way unless you fully control the network (see the manual's
+[Bus Service](https://tigregotico.github.io/ovos-technical-manual/bus-service/) page for why). See
+[docs/configuration.md](docs/configuration.md) for the full list of options, [docs/server.md](docs/server.md)
+for the server internals, and [docs/events.md](docs/events.md) for the message types that flow through the bus.
 
 ## Alternative implementations
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,32 +52,12 @@ The server reads its connection settings from `mycroft.conf` (the `websocket` se
 
 ## Configuration
 
-The server reads its configuration from `mycroft.conf` under the `websocket` key:
-
-| Key | Default | Description |
-|---|---|---|
-| `host` | `0.0.0.0` | Bind address |
-| `port` | `8181` | TCP port |
-| `route` | `/core` | WebSocket URL path |
-| `ssl` | `False` | Enable SSL/TLS (the Tornado backend serves `wss://` directly) |
-| `ssl_cert` / `ssl_key` | unset | PEM cert/key paths. The server generates a self-signed pair when unset (`ssl` extra) |
-| `max_msg_size` | `10` | Maximum message size in MB |
-
-Example `mycroft.conf` section:
-
-```json
-{
-  "websocket": {
-    "host": "0.0.0.0",
-    "port": 8181,
-    "route": "/core",
-    "ssl": false,
-    "ssl_cert": "",
-    "ssl_key": "",
-    "max_msg_size": 10
-  }
-}
-```
+The server reads its configuration from `mycroft.conf` under the `websocket` key. The shipped default
+`host` is `127.0.0.1`. Keep it that way: only set `0.0.0.0` if you fully control the network, and never
+port-forward 8181. See the manual's
+[Bus Service](https://tigregotico.github.io/ovos-technical-manual/bus-service/) page for the security
+rationale, and [docs/configuration.md](configuration.md) in this repo for the full per-key reference
+(defaults, source citations, `max_msg_size` behavior).
 
 ---
 


### PR DESCRIPTION
## Summary
- docs/index.md: fix the configuration table, which stated the wrong default bind address (`0.0.0.0` instead of the shipped `127.0.0.1`) and self-contradicted docs/configuration.md. Trimmed the duplicated table down to a short summary with a link to configuration.md and the manual's Bus Service page.
- README.md: fix the same wrong `0.0.0.0` example default and trim the config JSON snippet, which duplicated docs/configuration.md, to a short pointer.

The OVOS Technical Manual (https://tigregotico.github.io/ovos-technical-manual/) is the canonical, actively maintained doc set; these repo docs now point into it instead of drifting independently.

## Test plan
- [ ] Docs-only change, no code affected.
- [ ] Spot-check rendered links resolve on the manual site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)